### PR TITLE
FEATURE(oioproxy): Add a watch-file and location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,4 +44,10 @@ openio_oioproxy_options: []
 #  - proxy.ttl.services.master=5000000
 #  - proxy.url.path.maxlen=2048
 
+openio_oioproxy_location: "{{ ansible_hostname }}.{{ openio_oioproxy_serviceid }}"
+openio_oioproxy_slots:
+  "{{ [ openio_oioproxy_type, openio_oioproxy_type ~ '-' ~ openio_oioproxy_location.split('.')[:-2] \
+  | join('-') ] \
+  if openio_oioproxy_location.split('.') | length > 2 \
+  else [ openio_oioproxy_type ] }}"
 ...

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,22 +1,22 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: master
+  version: "19.04"
   name: repository
 
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: master
+  version: "19.04"
   name: users
 
 - src: https://github.com/open-io/ansible-role-openio-namespace.git
-  version: master
+  version: "19.04"
   name: namespace
 
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: master
+  version: "19.04"
   name: gridinit
 
 - src: https://github.com/open-io/ansible-role-openio-conscience.git
-  version: master
+  version: "19.04"
   name: conscience
 
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -8,9 +8,6 @@
     - role: users
     - role: repository
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
     - role: namespace
       openio_namespace_name: "{{ NS }}"
       openio_namespace_conscience_url: "{{ ansible_default_ipv4.address }}:6000"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
   with_items:
     - path: "/etc/gridinit.d/{{ openio_oioproxy_namespace }}"
     - path: "{{ openio_oioproxy_sysconfig_dir }}/{{ openio_oioproxy_servicename }}"
+    - path: "/etc/oio/sds/{{ openio_oioproxy_namespace }}/watch"
     - path: "/var/log/oio/sds/{{ openio_oioproxy_namespace }}/{{ openio_oioproxy_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
@@ -43,6 +44,8 @@
     - src: "gridinit_oioproxy.conf.j2"
       dest: "{{ openio_oioproxy_gridinit_dir }}/{{ openio_oioproxy_gridinit_file_prefix }}\
         {{ openio_oioproxy_servicename }}.conf"
+    - src: "watch-oioproxy.yml.j2"
+      dest: "{{ openio_oioproxy_sysconfig_dir }}/watch/{{ openio_oioproxy_servicename }}.yml"
   register: _oioproxy_conf
 
 - name: restart oioproxy

--- a/templates/watch-oioproxy.yml.j2
+++ b/templates/watch-oioproxy.yml.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+---
+host: {{ openio_oioproxy_bind_address }}
+port: {{ openio_oioproxy_bind_port }}
+type: oioproxy
+{% if openio_oioproxy_location | ipaddr %}
+location: {{ openio_oioproxy_location | replace(".", "-") }}
+{% else %}
+location: {{ openio_oioproxy_location }}
+{% endif %}
+checks:
+  - {type: tcp}
+stats:
+  - {type: oioproxy}
+  - {type: system}
+slots:
+  {{ openio_oioproxy_slots | to_nice_yaml | indent(2) }}
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 openio_oioproxy_sysconfig_dir: "/etc/oio/sds/{{ openio_oioproxy_namespace }}"
 openio_oioproxy_servicename: "oioproxy-{{ openio_oioproxy_serviceid }}"
+openio_oioproxy_type: oioproxy
 
 openio_oioproxy_definition_file: >
   "{{ openio_oioproxy_sysconfig_dir }}/


### PR DESCRIPTION
FEATURE(oioproxy): Add a watch-file and location

 ##### SUMMARY

In this release, the conscience is scoring the oioproxy

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
root@4293e4ac1bbe:/# cat /etc/oio/sds/TRAVIS/watch/oioproxy-0.yml
---
host: 172.17.0.2
port: 6006
type: oioproxy
location: 4293e4ac1bbe.0
checks:
  - {type: http}
stats:
  - {type: system}
slots:
  - oioproxy

...
```