### PR TITLE
BUGFIX/MINOR(oioproxy): Fix the use of tags `install` and `configure`

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -26,6 +26,8 @@
       openio_conscience_namespace: "{{ NS }}"
       openio_conscience_bind_address: "{{ ansible_default_ipv4.address }}"
       openio_conscience_pools: []
+      openio_conscience_inventory_groupname: all
+      openio_conscience_multiple: false
     - role: role_under_test
       openio_oioproxy_namespace: "{{ NS }}"
       openio_oioproxy_options:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -28,7 +30,7 @@
     - path: "/var/log/oio/sds/{{ openio_oioproxy_namespace }}/{{ openio_oioproxy_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
-  tags: install
+  tags: configure
 
 - name: Generate configuration files
   template:
@@ -47,6 +49,7 @@
     - src: "watch-oioproxy.yml.j2"
       dest: "{{ openio_oioproxy_sysconfig_dir }}/watch/{{ openio_oioproxy_servicename }}.yml"
   register: _oioproxy_conf
+  tags: configure
 
 - name: "restart oioproxy to apply the new configuration"
   shell: |
@@ -78,6 +81,7 @@
       delay: 5
       until: _oioproxy_check is success
       changed_when: false
+      tags: configure
       when:
         - not openio_oioproxy_provision_only
   when: openio_bootstrap | d(false)


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION