### PR TITLE
CHANGE(oioproxy): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An Ansible role for oioproxy. Specifically, the responsibilities of this role ar
 | `openio_oioproxy_options` | `[]` | List of options |
 | `openio_oioproxy_serviceid` | `"0"` | ID in gridinit |
 | `openio_oioproxy_version` | `latest` | Install a specific version |
+| `openio_oioproxy_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ openio_oioproxy_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 openio_oioproxy_version: 'latest'
 
 openio_oioproxy_provision_only: false
+openio_oioproxy_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_oioproxy_gridinit_dir: "/etc/gridinit.d/{{ openio_oioproxy_namespace }}"
 openio_oioproxy_gridinit_file_prefix: ""

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_oioproxy_package_upgrade else 'present' }}"
   with_items: "{{ oioproxy_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_oioproxy_package_upgrade else 'present' }}"
   with_items: "{{ oioproxy_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION