### PR TITLE
BUGFIX/MINOR(oioproxy): fix watch directory creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
     mode: "{{ item.mode | default(0755) }}"
   with_items:
     - path: "{{ openio_oioproxy_sysconfig_dir }}/{{ openio_oioproxy_servicename }}"
-    - path: "/etc/oio/sds/{{ openio_oioproxy_namespace }}/watch"
+    - path: "{{ openio_oioproxy_sysconfig_dir }}/watch"
     - path: "/var/log/oio/sds/{{ openio_oioproxy_namespace }}/{{ openio_oioproxy_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"


### PR DESCRIPTION
 ##### SUMMARY

watch files directory was hardcoded to `/etc/oio/sds/xxx/watch` during
its creation but later on the watch file was written to
`openio_xxx_sysconfig_dir`/watch/xxxx.yml

which can cause a bug when openio_xxx_sysconfig_dir override default
value

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION